### PR TITLE
Replace Enha wiki mirror with Namu wiki

### DIFF
--- a/frontend/js/WorkViews.js
+++ b/frontend/js/WorkViews.js
@@ -169,8 +169,8 @@ var Sidebar = React.createClass({
                 <div className="links">
                 {metadata.links.website &&
                     <p><i className="fa fa-globe" /> <a href={metadata.links.website} target="_blank">공식 사이트</a></p>}
-                {metadata.links.enha &&
-                    <p><i className="fa fa-globe" /> <a href={metadata.links.enha} target="_blank">엔하위키 미러</a></p>}
+                {metadata.links.namu &&
+                    <p><i className="fa fa-globe" /> <a href={metadata.links.namu} target="_blank">나무위키</a></p>}
                 {metadata.links.ann &&
                     <p><i className="fa fa-globe" /> <a href={metadata.links.ann} target="_blank">AnimeNewsNetwork (영문)</a></p>}
                 </div>

--- a/frontend/js/table-period-item.hbs
+++ b/frontend/js/table-period-item.hbs
@@ -35,8 +35,8 @@
 {{#if links.website}}
     <a href="{{links.website}}" class="link link-official" target="_blank">공식 사이트</a>
 {{/if}}
-{{#if links.enha}}
-    <a href="{{links.enha}}" class="link link-enha" target="_blank">엔하위키</a>
+{{#if links.namu}}
+    <a href="{{links.namu}}" class="link link-namu" target="_blank">나무위키</a>
 {{/if}}
 {{#if links.ann}}
     <a href="{{links.ann}}" class="link link-ann" target="_blank">ANN (en)</a>

--- a/table/models.py
+++ b/table/models.py
@@ -44,8 +44,8 @@ def item_json(item, period):
     data['links'] = {}
     if 'website' in item:
         data['links']['website'] = item['website']
-    if 'enha_ref' in item:
-        data['links']['enha'] = enha_link(item['enha_ref'])
+    if 'namu_ref' in item:
+        data['links']['namu'] = namu_link(item['namu_ref'])
     if 'ann_id' in item:
         data['links']['ann'] = 'http://www.animenewsnetwork.com/encyclopedia/anime.php?id=' + str(item['ann_id'])
 
@@ -91,14 +91,14 @@ def parse_date(s, period):
     h, min = map(int, time.split(':'))
     return datetime.datetime(y, m, d, h, min)
 
-def enha_link(ref):
+def namu_link(ref):
     t = ref.rsplit('#', 1)
     if len(t) == 2:
         page, anchor = t
     else:
         page = ref
         anchor = None
-    url = 'http://mirror.enha.kr/wiki/' + urllib.quote(page.encode('utf-8'))
+    url = 'https://namu.wiki/w/' + urllib.quote(page.encode('utf-8'))
     if anchor:
         url += '#' + urllib.quote(anchor.encode('utf-8'))
     return url


### PR DESCRIPTION
Fix #23.

Renamed `enha` to `namu`, `enha_ref` to `namu_ref`, and `enha_link` to `namu_link`. I think the `schedule.yml` of production server should be modified before the merge.